### PR TITLE
Client registration

### DIFF
--- a/client/src/args.rs
+++ b/client/src/args.rs
@@ -10,7 +10,7 @@ pub struct GlobalArgs {
     #[arg(long, short, default_value = "https://clusterizer.mcathome.dev")]
     pub server_url: String,
     #[clap(subcommand)]
-    pub command: Option<Commands>,
+    pub command: Commands,
 }
 
 #[derive(Debug, Subcommand)]

--- a/client/src/args.rs
+++ b/client/src/args.rs
@@ -1,18 +1,38 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "Clusterizer RS")]
 #[command(version)]
 #[command(about = "Crunching tasks since 2k20", long_about = None)]
-pub struct Args {
-    #[arg(long, short, default_value = ".")]
-    pub data_path: PathBuf,
-    #[arg(long, short)]
-    pub api_key: Option<String>,
+pub struct GlobalArgs {
     #[arg(long, short, default_value = "https://clusterizer.mcathome.dev")]
     pub server_url: String,
-    #[arg(long, short)]
+    #[clap(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Supply user_name and optional server_url to register for clusterizer
+    Register(RegisterArgs),
+    /// Supply api_key, optional data_path, optional server_url, and a platform id to begin crunching on clusterizer
+    Run(RunArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct RunArgs {
+    #[clap(long, short, default_value = ".")]
+    pub data_path: PathBuf,
+    #[clap(long, short)]
+    pub api_key: Option<String>,
+    #[clap(long, short)]
     pub platform_id: i64,
+}
+
+#[derive(Debug, Args)]
+pub struct RegisterArgs {
+    #[clap(long, short)]
+    pub username: String,
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -9,8 +9,10 @@ use std::{
     time::Duration,
 };
 
-
-use clusterizer_common::{messages::{RegisterRequest, RegisterResponse, SubmitRequest}, types::Task};
+use clusterizer_common::{
+    messages::{RegisterRequest, RegisterResponse, SubmitRequest},
+    types::Task,
+};
 use tokio::process::Command;
 use zip::ZipArchive;
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -9,10 +9,7 @@ use std::{
     time::Duration,
 };
 
-use clusterizer_common::{
-    messages::{RegisterRequest, RegisterResponse, SubmitRequest},
-    types::Task,
-};
+use clusterizer_common::{messages::SubmitRequest, types::Task};
 use tokio::process::Command;
 use zip::ZipArchive;
 
@@ -25,17 +22,12 @@ pub struct ClusterizerClient {
 }
 
 impl ClusterizerClient {
-    pub async fn new(args: RunArgs, server_url: String) -> ClusterizerClient {
+    pub fn new(args: RunArgs, server_url: String) -> ClusterizerClient {
         ClusterizerClient {
             api_client: clusterizer_api::Client::new(server_url, args.api_key),
             data_path: args.data_path,
             platform_id: args.platform_id,
         }
-    }
-    pub async fn register(server_url: String, user_name: String) -> ClientResult<RegisterResponse> {
-        Ok(clusterizer_api::Client::new(server_url, None)
-            .register_user(&RegisterRequest { name: user_name })
-            .await?)
     }
     pub async fn run(&self) -> ClientResult<()> {
         loop {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,7 +1,7 @@
-use args::Args;
+use args::{Commands, GlobalArgs};
 use clap::Parser;
 use client::ClusterizerClient;
-use result::ClientResult;
+use result::{ClientError, ClientResult};
 
 mod args;
 mod client;
@@ -9,5 +9,28 @@ mod result;
 
 #[tokio::main]
 async fn main() -> ClientResult<()> {
-    ClusterizerClient::from(Args::parse()).run().await
+    let global_args = GlobalArgs::parse();
+
+    match global_args.command {
+        Some(Commands::Register(register_args)) => {
+            let register_response =
+                ClusterizerClient::register(global_args.server_url, register_args.username).await;
+            match register_response {
+                Ok(register_content) => {
+                    println!("Api Key: {} ", register_content.api_key);
+                }
+                Err(_) => {
+                    return Err(ClientError::RegistrationError);
+                }
+            }
+            Ok(())
+        }
+        Some(Commands::Run(run_args)) => {
+            Ok(ClusterizerClient::new(run_args, global_args.server_url)
+                .await
+                .run()
+                .await?)
+        }
+        None => Err(ClientError::NoCommand),
+    }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -19,18 +19,17 @@ async fn main() -> ClientResult<()> {
     let global_args = GlobalArgs::parse();
 
     match global_args.command {
-        Some(Commands::Register(register_args)) => {
+        Commands::Register(register_args) => {
             let register_response =
                 register(global_args.server_url, register_args.username).await?;
             println!("Api Key: {} ", register_response.api_key);
 
             Ok(())
         }
-        Some(Commands::Run(run_args)) => {
+        Commands::Run(run_args) => {
             Ok(ClusterizerClient::new(run_args, global_args.server_url)
                 .run()
                 .await?)
         }
-        None => Ok(()),
     }
 }

--- a/client/src/result.rs
+++ b/client/src/result.rs
@@ -9,10 +9,6 @@ pub enum ClientError {
     Reqwest(#[from] reqwest::Error),
     Zip(#[from] ZipError),
     Io(#[from] io::Error),
-    #[error("no command given")]
-    NoCommand,
-    #[error("registration failed")]
-    RegistrationError,
 }
 
 pub type ClientResult<T> = Result<T, ClientError>;

--- a/client/src/result.rs
+++ b/client/src/result.rs
@@ -9,6 +9,10 @@ pub enum ClientError {
     Reqwest(#[from] reqwest::Error),
     Zip(#[from] ZipError),
     Io(#[from] io::Error),
+    #[error("no command given")]
+    NoCommand,
+    #[error("registration failed")]
+    RegistrationError,
 }
 
 pub type ClientResult<T> = Result<T, ClientError>;


### PR DESCRIPTION
Splits the client into two commands, register and run.

Allows for api registration via the client, rather than relying on a curl command.

Fixes #17 