### PR TITLE
delete slot when finished task

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -82,7 +82,7 @@ impl ClusterizerClient {
 
         let output = Command::new(program)
             .args(args)
-            .current_dir(slot_path)
+            .current_dir(&slot_path)
             .output()
             .await?;
 
@@ -93,7 +93,7 @@ impl ClusterizerClient {
         };
 
         self.api_client.submit_task(task.id, &result).await?;
-
+        fs::remove_dir_all(slot_path)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Fairly straightforward. Just some cleanup so we're not leaving slot directories.